### PR TITLE
Create defaults for 802.11s 

### DIFF
--- a/contrib/package/community-profiles/files/etc/config/profile_berlin
+++ b/contrib/package/community-profiles/files/etc/config/profile_berlin
@@ -31,6 +31,9 @@ config 'defaults' 'ssidscheme'
 	option '13'	'intern-ch13.freifunk.net'
 	option '36'	'intern-ch36.freifunk.net'
 
+config 'defaults' 'wifi_iface_80211s'
+	option 'mesh_id' 'Mesh-Freifunk-Berlin'
+
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
 	option 'dns' '85.214.20.141 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12'

--- a/contrib/package/freifunk-common/files/etc/config/freifunk
+++ b/contrib/package/freifunk-common/files/etc/config/freifunk
@@ -104,6 +104,12 @@ config 'defaults' 'wifi_iface'
 	option 'bssid' '12:CA:FF:EE:BA:BE'
 	option 'mcast_rate' '6000'
 
+config 'defaults' 'wifi_iface_80211s'
+	option 'mode' 'mesh'
+	option 'encryption' 'none'
+	option 'mesh_id' 'Mesh-Freifunk'
+	option 'mesh_fwding' '0'
+
 config 'defaults' 'interface'
 	option 'netmask' '255.255.0.0'
 	option 'dns' '8.8.8.8 212.204.49.83 141.1.1.1'


### PR DESCRIPTION
Add default values for freifunk and profile_berlin.

defaults are for /etc/config/freifunk are

config 'defaults' 'wifi_iface_80211s'
      option 'mode' 'mesh'
      option 'encryption' 'none'
      option 'mesh_id' 'Mesh-Freifunk'
      option 'mesh_fwding' '0'

the defaults for profile_berlin are

config 'defaults' 'wifi_iface_80211s'
      option 'mesh_id' 'Mesh-Freifunk-Berlin'