### PR TITLE
luci-mod-freifunk: reduce usage of string.gsub()

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/model/cbi/freifunk/basics.lua
+++ b/modules/luci-mod-freifunk/luasrc/model/cbi/freifunk/basics.lua
@@ -15,8 +15,9 @@ community.rmempty = false
 
 local profile
 for profile in fs.glob(profiles) do
-	local name = uci:get_first(string.gsub(profile, "/etc/config/", ""), "community", "name") or "?"
-	community:value(string.gsub(profile, "/etc/config/profile_", ""), name)
+	profile = string.gsub(profile, "/etc/config/profile_", "")
+	local name = uci:get_first("profile_" .. profile, "community", "name") or "?"
+	community:value(profile, name)
 end
 
 


### PR DESCRIPTION
rearrange the code to not use gsub() two times.
Calling one time gsub and concat a string will be faster then using gsub() two times.

Signed-off-by: Sven Roederer <freifunk@it-solutions.geroedel.de>