### PR TITLE
ff_olsr_watchdog: don't run when the plugin is not active

### DIFF
--- a/contrib/package/freifunk-common/files/usr/sbin/ff_olsr_watchdog
+++ b/contrib/package/freifunk-common/files/usr/sbin/ff_olsr_watchdog
@@ -12,6 +12,9 @@ if fs.access("/var/run/olsrd.pid") or fs.access("/var/run/olsrd4.pid") then
 	x:foreach("olsrd", "LoadPlugin",
 		function(s)
 			if s.library == "olsrd_watchdog" then
+				if s.ignore == "1" then
+					do return end
+				end
 				intv  = tonumber(s.interval)
 				stamp = s.file
 			end


### PR DESCRIPTION
Don't do anything, when the watchdog-plugin is deactivated via uci option "ignore=1".
