### PR TITLE
freifunk-common: use micrond to trigger olsr_watchdog

### DIFF
--- a/contrib/package/freifunk-common/Makefile
+++ b/contrib/package/freifunk-common/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-common
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
@@ -15,7 +15,7 @@ define Package/freifunk-common
   CATEGORY:=LuCI
   SUBMENU:=9. Freifunk
   TITLE:=Freifunk common files
-  DEPENDS:=+libuci-lua +olsrd
+  DEPENDS:=+libuci-lua +olsrd +micrond
 endef
 
 define Package/freifunk-common/description

--- a/contrib/package/freifunk-common/files/etc/init.d/freifunk
+++ b/contrib/package/freifunk-common/files/etc/init.d/freifunk
@@ -11,10 +11,6 @@ boot() {
 		echo "*/5 * * * *	killall -HUP dnsmasq" >> /etc/crontabs/root
 	}
 
-	grep -q '/usr/sbin/ff_olsr_watchdog' /etc/crontabs/root || {
-		echo "*/5 * * * *	/usr/sbin/ff_olsr_watchdog" >> /etc/crontabs/root
-	}
-
 	[ -d /etc/rc.local.d ] && {
 		for file in /etc/rc.local.d/*; do
 			test -f "$file" && . "$file"

--- a/contrib/package/freifunk-common/files/usr/micron.d/ff_olsr_watchdog
+++ b/contrib/package/freifunk-common/files/usr/micron.d/ff_olsr_watchdog
@@ -1,0 +1,1 @@
+*/5 * * * *	/usr/sbin/ff_olsr_watchdog


### PR DESCRIPTION
Maintaining the cronjobs in separate files seems much more simple than in a global crontab file.
This is esp. relevant for updating or removing the cronjob.