### PR TITLE
mod-freifunk: add UCI-setting to configure an alternative landingpage

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/view/freifunk/index.htm
+++ b/modules/luci-mod-freifunk/luasrc/view/freifunk/index.htm
@@ -4,9 +4,22 @@
  Licensed to the public under the Apache License 2.0.
 -%>
 
-<%+header%>
 <% 
 local uci = require "luci.model.uci".cursor()
+local http = require "luci.http"
+
+local webAppRoot = http.getenv("PATH_INFO") == nil
+local redirectPage = uci:get("freifunk", "luci", "redirect_landingpage") or ""
+
+if (webAppRoot and redirectPage ~= "") then
+        local url = luci.dispatcher.build_url(redirectPage)
+        http.redirect(url)
+end
+%>
+
+<%+header%>
+
+<% 
 local tpl = require "luci.template"
 local fs = require "nixio.fs"
 


### PR DESCRIPTION
With this change there can an alternative landingpage defined via UCI "freifunk.luci.redirect_landingpage". When this option is defined, the browser will be redirected to this luci-page. Without this option the current behaviour will be kept.
So it's possible to present a setup-wizard to the user when accessing http://<node>/cgi-bin/luci. An example uci-section can look like:

> config setting 'luci'
  	option 'landingpage' 'admin/freifunk/assistent'
