### PR TITLE
community-profiles: update profiles to use the new digitalcourage nameservers

### DIFF
--- a/contrib/package/community-profiles/Makefile
+++ b/contrib/package/community-profiles/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=community-profiles
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/community-profiles/files/etc/config/profile_berlin
+++ b/contrib/package/community-profiles/files/etc/config/profile_berlin
@@ -36,7 +36,7 @@ config 'defaults' 'wifi_iface_80211s'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '85.214.20.141 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12'
+	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12 2a02:2970:1002::18'
 
 config 'dhcp' 'dhcp'
 	option leasetime '5m'

--- a/contrib/package/community-profiles/files/etc/config/profile_cottbus
+++ b/contrib/package/community-profiles/files/etc/config/profile_cottbus
@@ -31,7 +31,7 @@ config 'defaults' 'ssidscheme'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '85.214.20.141 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12'
+	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12 2a02:2970:1002::18'
 
 config 'dhcp' 'dhcp'
 	option 'leasetime' '5m'

--- a/contrib/package/community-profiles/files/etc/config/profile_fuerstenwalde
+++ b/contrib/package/community-profiles/files/etc/config/profile_fuerstenwalde
@@ -32,7 +32,7 @@ config 'defaults' 'ssidscheme'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.255.255'
-	option 'dns' '85.214.20.141 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12'
+	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12 2a02:2970:1002::18'
 
 config 'dhcp' 'dhcp'
 option leasetime '5m'

--- a/contrib/package/community-profiles/files/etc/config/profile_potsdam
+++ b/contrib/package/community-profiles/files/etc/config/profile_potsdam
@@ -11,7 +11,7 @@ config 'community' 'profile'
 
 config 'defaults' 'interface'
 	option 'netmask' '255.255.0.0'
-	option 'dns' '85.214.20.141 80.67.169.40 194.150.168.168'
+	option 'dns' '46.182.19.48 80.67.169.40 194.150.168.168'
 	option 'delegate' '0'
 
 config 'defaults' 'wifi_device'


### PR DESCRIPTION
The old digitalcourage nameservers 85.214.20.141 and 2a01:238:42f6:ac00:2a29:4f7f:b6d:ef46
will be retired in 2020.  The new nameservers are 46.182.19.48 and 2a02:2970:1002::18.

The change is announced https://digitalcourage.de/support/zensurfreier-dns-server

This fixes https://github.com/freifunk/openwrt-packages/issues/11

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>