### PR TITLE
Policyrouting: Fix "file not found errors" when using imagebuilder

### DIFF
--- a/contrib/package/freifunk-policyrouting/Makefile
+++ b/contrib/package/freifunk-policyrouting/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-policyrouting
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
@@ -34,14 +34,6 @@ endef
 
 define Package/freifunk-policyrouting/install
 	$(CP) ./files/* $(1)/
-endef
-
-define Package/freifunk-policyrouting/postinst
-#!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || {
-	/etc/init.d/freifunk-policyrouting enabled || /etc/init.d/freifunk-policyrouting enable
-	exit 0
-}
 endef
 
 $(eval $(call BuildPackage,freifunk-policyrouting))

--- a/contrib/package/freifunk-policyrouting/files/etc/init.d/freifunk-policyrouting
+++ b/contrib/package/freifunk-policyrouting/files/etc/init.d/freifunk-policyrouting
@@ -1,8 +1,8 @@
 #!/bin/sh /etc/rc.common
 
 START=15
-. /lib/functions/network.sh
-. /lib/functions.sh
+. $IPKG_INSTROOT/lib/functions/network.sh
+. $IPKG_INSTROOT/lib/functions.sh
 
 proto="4"
 [ -f /proc/net/ipv6_route ] && proto="4 6"


### PR DESCRIPTION
Fix takes care of issue #10, by:
* not enabling the init-script explicitly via postinst
* honoring $IPKG_INSTROOT when running the init-script