### PR TITLE
freifunk-common: ff_olsr_watchdog requires luci.model.uci

### DIFF
--- a/contrib/package/freifunk-common/Makefile
+++ b/contrib/package/freifunk-common/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-common
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
@@ -31,7 +31,7 @@ define Package/freifunk-common-olsr
   CATEGORY:=LuCI
   SUBMENU:=9. Freifunk
   TITLE:=Freifunk common files for olsr-v1
-  DEPENDS:=freifunk-common +olsrd +micrond
+  DEPENDS:=freifunk-common +olsrd +micrond +libuci-lau
 endef
 
 define Package/freifunk-common-olsr/description


### PR DESCRIPTION
The script ff_olsr_watchdog fails with the snapshot images because
it required "uci" which is no longer a globally accessable library
and resulted in a failure.  The script has been updated to require
"luci.model.uci".

This has been tested on the freifunk-berlin firmware based on LEDE
up until the newest snapshot.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>