### PR TITLE
luci-mod-freifunk: add dependency to luci-compat

### DIFF
--- a/modules/luci-mod-freifunk/Makefile
+++ b/modules/luci-mod-freifunk/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Freifunk module
-LUCI_DEPENDS:=+luci-mod-admin-full +luci-lib-json +luci-lib-ipkg +freifunk-firewall +freifunk-common
+LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +luci-lib-json +luci-lib-ipkg +freifunk-firewall +freifunk-common
 
 include ../../freifunk.mk
 


### PR DESCRIPTION
this fixes the error seen in the admin-interface after login

/usr/lib/lua/luci/dispatcher.lua:1342: module 'luci.cbi' not found:
	no field package.preload['luci.cbi']
	no file './luci/cbi.lua'
	no file '/usr/share/lua/luci/cbi.lua'
	no file '/usr/share/lua/luci/cbi/init.lua'
	no file '/usr/lib/lua/luci/cbi.lua'
	no file '/usr/lib/lua/luci/cbi/init.lua'
	no file './luci/cbi.so'
	no file '/usr/lib/lua/luci/cbi.so'
	no file '/usr/lib/lua/loadall.so'
	no file './luci.so'
	no file '/usr/lib/lua/luci.so'
	no file '/usr/lib/lua/loadall.so'

The luci-compat packaged was added in LuCI when reworking to JS-based framework was done, to provide backward compatibility to the Lua-based framework (up to OpenWrt-18.06).
