### PR TITLE
freifunk-common: make olsr status available again for unauthed users

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/controller/freifunk/freifunk.lua
+++ b/modules/luci-mod-freifunk/luasrc/controller/freifunk/freifunk.lua
@@ -52,6 +52,7 @@ function index()
 	page = assign({"freifunk", "olsr"}, {"admin", "status", "olsr"}, _("OLSR"), 30)
 	page.setuser = false
 	page.setgroup = false
+	page.acl_depends = {}
 
 	if nixio.fs.access("/etc/config/luci_statistics") then
 		assign({"freifunk", "graph"}, {"admin", "statistics", "graph"}, _("Statistics"), 40)


### PR DESCRIPTION
Due to addition of acl-dependencies in luci, the olsr status page was not accessible by users that were not logged in.
This patch fixes this. I hope this is the right way to do it as I'm not that deep into the luci codebase and the documentation is not that great...