### PR TITLE
luci-mod-freifunk: fix permissions for uci access

### DIFF
--- a/modules/luci-mod-freifunk/root/usr/share/rpcd/acl.d/luci-mod-freifunk.json
+++ b/modules/luci-mod-freifunk/root/usr/share/rpcd/acl.d/luci-mod-freifunk.json
@@ -1,0 +1,11 @@
+{
+	"luci-mod-freifunk": {
+		"description": "Provdies access to freifunk",
+		"read": {
+			"uci": [ "freifunk", "profile_*" ],
+		},
+		"write": {
+			"uci": [ "freifunk", "profile_*" ],
+		}
+	}
+}


### PR DESCRIPTION
as requested in PR #28 a pull request that adds the necessary file to fix the uci access permissions.
As I don't have the device I tested this with here with me this commit is untested so please compile the package with this branch and test if you can access the profile settings page.