### PR TITLE
freifunk-common: set default mcate_rate for 802.11s

### DIFF
--- a/contrib/package/freifunk-common/Makefile
+++ b/contrib/package/freifunk-common/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-common
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-common/files-common/etc/config/freifunk
+++ b/contrib/package/freifunk-common/files-common/etc/config/freifunk
@@ -121,4 +121,5 @@ config 'defaults' 'wifi_iface_80211s'
 	option 'encryption' 'none'
 	option 'mesh_id' 'Mesh-Freifunk'
 	option 'mesh_fwding' '0'
+	option 'mcast_rate' '12000'
 


### PR DESCRIPTION
Set the default mcast_rate for 802.11s to 12000.  This
value is derived from the experiences made at Freifunk Berlin
and the best working value for both 2.4 and 5Ghz for the
largest running 802.11s mesh-island in the network.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>