### PR TITLE
Theme Freifunk: backports from OpenWrt-2020 theme

### DIFF
--- a/themes/luci-theme-freifunk-generic/htdocs/luci-static/freifunk-generic/cascade.css
+++ b/themes/luci-theme-freifunk-generic/htdocs/luci-static/freifunk-generic/cascade.css
@@ -5,6 +5,7 @@
 	--secondary-dark-color: #212322;
 	--danger-color: #CC1111;
 	--warning-color: #CC8800;
+	--success-color: #5CB85C;
 	--regular-font: "GalanoGrotesqueW00-Regular";
 	--base-font-size: 16px;
 }
@@ -851,6 +852,10 @@ ul > li {
 
 .alert-message.danger {
 	background: var(--danger-color);
+}
+
+.alert-message.success {
+	background: var(--success-color);
 }
 
 .alert-message .btn {

--- a/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
+++ b/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
@@ -19,7 +19,7 @@
 
 	http.prepare_content("text/html; charset=UTF-8")
 -%>
-
+<!DOCTYPE html>
 <html lang="<%=luci.i18n.context.lang%>">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
+++ b/themes/luci-theme-freifunk-generic/luasrc/view/themes/freifunk-generic/header.htm
@@ -30,6 +30,10 @@
 <script type="text/javascript" src="<%=url('admin/translations', luci.i18n.context.lang)%><%# ?v=PKG_VERSION %>"></script>
 <script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <title><%=striptags( (boardinfo.hostname or "?") .. ( (node and node.title) and ' - ' .. translate(node.title) or '')) %> - LuCI</title>
+<% if css then %><style title="text/css">
+<%= css %>
+</style>
+<% end -%>
 </head>
 <body class="lang_<%=luci.i18n.context.lang%>" data-page="<%= pcdata(path) %>">
 


### PR DESCRIPTION
backport some changes from upstream luci-theme "OpenWrt-2020" since we have imported it to modification. backports the following commits (which are common for master and openwrt-2102 branches):

* https://github.com/openwrt/luci/commit/4a00f5bd8e3f609e08bb9d62f1d5bfa0b6ab3924
* https://github.com/openwrt/luci/commit/e0c0e468e64e9b425784650c23a894b8a0f4d407
* https://github.com/openwrt/luci/commit/c5ff3244e92f267e3b7410b3196615f5fec75051
