### PR TITLE
mod-freifunk: fix LuCI-error when selecting "Freifunk" (seems related to dropping privileges)

### DIFF
--- a/modules/luci-mod-freifunk/luasrc/controller/freifunk/freifunk.lua
+++ b/modules/luci-mod-freifunk/luasrc/controller/freifunk/freifunk.lua
@@ -18,8 +18,9 @@ function index()
 	page.title    = _("Freifunk")
 	page.target   = alias("freifunk", "index")
 	page.order    = 5
-	page.setuser  = "nobody"
-	page.setgroup = "nogroup"
+-- TODO: fix issue #33 and drop privileges again
+--	page.setuser  = "nobody"
+--	page.setgroup = "nogroup"
 	page.i18n     = "freifunk"
 	page.index    = true
 


### PR DESCRIPTION
based on the findings in https://github.com/freifunk/openwrt-packages/issues/33#issuecomment-835891129 make the Freifunk-Mod usable again.

This is just an WIP-draft for explicit discussion to find a proper fix.