### PR TITLE
import luci-app-owm from Freifunk-Berlin repo

### DIFF
--- a/applications/luci-app-owm/Makefile
+++ b/applications/luci-app-owm/Makefile
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2012-2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=luci-app-owm
+PKG_RELEASE:=0.4.20
+
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/luci-app-owm/default
+  SECTION:=luci
+  CATEGORY:=LuCI
+  SUBMENU:=3. Applications
+  URL:=https://github.com/freifunk-berlin/firmware-packages
+  PKGARCH:=all
+endef
+
+define Package/luci-app-owm
+  $(call Package/luci-app-owm/default)
+  DEPENDS:=+luci-lib-json +olsrd-mod-jsoninfo +luci-lib-ip
+  TITLE:=Luci JSON Export for Open Wireless Map
+endef
+
+define Package/luci-app-owm/description
+  Luci JSON Export for Open Wireless Map
+endef
+
+define Package/luci-app-owm-cmd
+  $(call Package/luci-app-owm/default)
+  DEPENDS:=luci-app-owm +luci-lib-httpclient
+  TITLE:=luci-app-owm-cmd - Commandline update tool
+endef
+
+define Package/luci-app-owm-gui
+  $(call Package/luci-app-owm/default)
+  DEPENDS:=luci-app-owm +luci-base
+  TITLE:=luci-app-owm-gui - GUI Open Wireless Map
+endef
+define Package/luci-app-owm-ant
+  $(call Package/luci-app-owm/default)
+  DEPENDS:=luci-app-owm +luci-base
+  TITLE:=luci-app-owm-ant - GUI Antenna settings
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) ./luasrc $(PKG_BUILD_DIR)/
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/luasrc
+endef
+
+define Package/luci-app-owm-cmd/postinst
+#!/bin/sh
+if [ -z $${IPKG_INSTROOT} ] ; then
+	( . /etc/uci-defaults/owm ) && rm -f /etc/uci-defaults/owm
+	rm -f /tmp/luci-indexcache
+fi
+endef
+
+define Package/luci-app-owm-cmd/install
+	$(INSTALL_DIR) $(1)/usr/sbin/
+	$(CP) files/owm.lua $(1)/usr/sbin/owm.lua
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(CP) files/owm-defaults $(1)/etc/uci-defaults/owm
+endef
+
+define Package/luci-app-owm-gui/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/controller
+	$(CP) $(PKG_BUILD_DIR)/luasrc/controller/owm.lua $(1)/usr/lib/lua/luci/controller/owm.lua
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view
+	$(CP) $(PKG_BUILD_DIR)/luasrc/view/owm.htm $(1)/usr/lib/lua/luci/view/owm.htm
+endef
+
+define Package/luci-app-owm-ant/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/controller
+	$(CP) $(PKG_BUILD_DIR)/luasrc/controller/antennas.lua $(1)/usr/lib/lua/luci/controller/antennas.lua
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/model/cbi
+	$(CP) $(PKG_BUILD_DIR)/luasrc/model/cbi/antennas.lua $(1)/usr/lib/lua/luci/model/cbi/antennas.lua
+endef
+
+define Package/luci-app-owm/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci
+	$(CP) $(PKG_BUILD_DIR)/luasrc/owm.lua $(1)/usr/lib/lua/luci/owm.lua
+endef
+
+$(eval $(call BuildPackage,luci-app-owm))
+$(eval $(call BuildPackage,luci-app-owm-cmd))
+$(eval $(call BuildPackage,luci-app-owm-gui))
+$(eval $(call BuildPackage,luci-app-owm-ant))
+

--- a/applications/luci-app-owm/Makefile
+++ b/applications/luci-app-owm/Makefile
@@ -1,6 +1,3 @@
-#
-# Copyright (C) 2012-2013 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -8,12 +5,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.4.20
-
+PKG_RELEASE:=0.5.0
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
-
-
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -21,7 +15,7 @@ define Package/luci-app-owm/default
   SECTION:=luci
   CATEGORY:=LuCI
   SUBMENU:=3. Applications
-  URL:=https://github.com/freifunk-berlin/firmware-packages
+  URL:=https://github.com/freifunk/openwrt-packages
   PKGARCH:=all
 endef
 
@@ -102,4 +96,3 @@ $(eval $(call BuildPackage,luci-app-owm))
 $(eval $(call BuildPackage,luci-app-owm-cmd))
 $(eval $(call BuildPackage,luci-app-owm-gui))
 $(eval $(call BuildPackage,luci-app-owm-ant))
-

--- a/applications/luci-app-owm/files/antennas.config
+++ b/applications/luci-app-owm/files/antennas.config
@@ -1,0 +1,18 @@
+
+config wifi-device 'radio0'
+        option builtin 'false'        
+        option manufacturer 'Buffalo'
+        option model 'whr-AG105'
+        option type 'omni'
+        option gain '4'
+        option polarization 'horizontal'
+
+config wifi-device 'radio1'
+	option builtin 'false'
+	option manufacturer 'Buffalo'
+	option model 'whr54g'
+	option type 'omni'
+	option gain '2'
+	option polarization 'vertical'
+
+	

--- a/applications/luci-app-owm/files/owm-defaults
+++ b/applications/luci-app-owm/files/owm-defaults
@@ -1,0 +1,5 @@
+#!/bin/sh
+test -f /etc/crontabs/root || touch /etc/crontabs/root
+SEED="$( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi )"
+MIN="$(( $SEED % 59 ))"
+crontab -l | grep -q "owm.lua" || crontab -l | { cat; echo "$MIN * * * *	test -e /usr/sbin/owm.lua && /usr/sbin/owm.lua"; } | crontab -

--- a/applications/luci-app-owm/files/owm.lua
+++ b/applications/luci-app-owm/files/owm.lua
@@ -1,0 +1,118 @@
+#!/usr/bin/lua
+
+require("luci.util")
+require("luci.model.uci")
+require("luci.sys")
+require("nixio.fs")
+require("luci.httpclient")
+
+-- Print help text
+function print_help()
+	print("owm.lua - Tool for registering routers at openwifimap.net\n")
+	print("Options:\
+        -\-help|-h:\tprint this text\
+	\
+        -\-dry-run:\tcheck if owm.lua is working (does not paste any data).\
+	\t\tWith this option you can check for errors in your\
+	\t\tconfiguration and test the transmission of data to\
+	\t\tthe map.")
+	print("\nIf invoked without any options, this tool\
+will try to register your node at the community-map,\
+but will execute silently. To work correctly, this tool\
+will need at least the geo-location of the node (check\
+with -\-dry-run).\
+\
+To override the server used by this script, set freifunk.community.owm_api.\
+")
+end
+
+-- check for arguments
+if (#arg) > 0 and arg[1]~="--dry-run" then
+   print_help()
+   return
+end
+
+-- Init state session
+local uci = luci.model.uci.cursor_state()
+local owm = require "luci.owm"
+local json = require "luci.json"
+local lockfile = "/var/run/owm.lock"
+local hostname
+
+--function db_put(uri,body)
+function db_put(owm_api,hostname,suffix,body)
+	local httpc = luci.httpclient
+	local uri_update = owm_api.."/update_node/"..hostname.."."..suffix
+	
+	local options = {
+		method = "PUT",
+		body = body,
+		headers = {
+			["Content-Type"] = "application/json",
+		},
+	}
+	
+	local response, code, msg = httpc.request_to_buffer(uri_update, options)
+
+	if code == 201 then
+		print("update Doc  Statuscode: "..code.." "..uri_update.." ("..msg..")")
+	elseif code then
+		print("fail   Doc  Statuscode: "..code.." "..uri_update.." ("..msg..")")
+	end
+end
+
+
+function lock()
+	if nixio.fs.access(lockfile) then
+		local timediff = os.time() - nixio.fs.stat(lockfile, "mtime")
+		if timediff < 3600 then
+			print(lockfile.." exists, time since lock: "..timediff)
+			os.exit()
+		end
+	else
+		os.execute("lock "..lockfile)
+	end
+end
+
+function unlock()
+	os.execute("lock -u "..lockfile)
+	os.execute("rm -f "..lockfile)
+end
+
+-- location for the node is required
+if owm.get_position()==nil then
+	if arg[1]=="--dry-run" then
+		print("no latitude/longitude specified for node.")
+	end
+	unlock()
+	return
+end
+
+lock()
+
+uci:foreach("system", "system", function(s)
+	hostname = s.hostname
+end)
+
+local owm_api = uci:get("freifunk", "community", "owm_api") or "http://api.openwifimap.net/"
+local cname = uci:get("freifunk", "community", "name") or "freifunk"
+local suffix = uci:get("freifunk", "community", "suffix") or uci:get("profile_" .. cname, "profile", "suffix") or "olsr"
+local body = json.encode(owm.get())
+
+if arg[1]=="--dry-run" then
+	print(body)
+	unlock()
+	return
+end
+
+if type(owm_api)=="table" then
+	for i,v in ipairs(owm_api) do 
+		local owm_api = v
+		db_put(owm_api,hostname,suffix,body)
+	end
+else
+	db_put(owm_api,hostname,suffix,body)
+end
+
+unlock()
+

--- a/applications/luci-app-owm/luasrc/Makefile
+++ b/applications/luci-app-owm/luasrc/Makefile
@@ -1,0 +1,8 @@
+LUAC = luac
+LUAC_OPTIONS = -s
+
+world: compile
+
+compile:
+	for i in $$(find -name *.lua -not -name debug.lua); do $(LUAC) $(LUAC_OPTIONS) -o $$i $$i; done
+

--- a/applications/luci-app-owm/luasrc/controller/antennas.lua
+++ b/applications/luci-app-owm/luasrc/controller/antennas.lua
@@ -1,0 +1,23 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2013 Patrick Grimm <patrick@lunatiki.de>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+
+]]--
+
+module("luci.controller.antennas", package.seeall)
+
+function index()
+	local page = entry({"admin", "system", "antennas"}, cbi("antennas"), "Antennas settings", 10)
+	page.dependent = true	
+	assign({"mini", "system", "antennas"}, {"admin", "system", "antennas"}, "Antennnas settings", 1)
+end
+

--- a/applications/luci-app-owm/luasrc/controller/owm.lua
+++ b/applications/luci-app-owm/luasrc/controller/owm.lua
@@ -1,0 +1,38 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2008 Steven Barth <steven@midlink.org>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+module("luci.controller.owm", package.seeall)
+
+function index()
+	entry({"owm.json"}, call("getjsonowm"))
+
+	local page = node("owm")
+	page.target = template("owm")
+	page.title = "OpenWifiMap"
+	page.order = 100
+end
+
+function getjsonowm()
+	local root = {}
+	local sys = require "luci.sys"
+	local uci = require "luci.model.uci"
+	local util = require "luci.util"
+	local http = require "luci.http"
+	local ltn12 = require "luci.ltn12"
+	local json = require "luci.json"
+	local owm = require "luci.owm"
+	http.prepare_content("application/json")
+	ltn12.pump.all(json.Encoder(owm.get()):source(), http.write)
+end
+

--- a/applications/luci-app-owm/luasrc/model/cbi/antennas.lua
+++ b/applications/luci-app-owm/luasrc/model/cbi/antennas.lua
@@ -1,0 +1,104 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2013 Patrick Grimm <patrick@lunatiki.de>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+
+]]--
+
+local fs  = require "nixio.fs"
+local uci = require "luci.model.uci".cursor()
+local has_wireless = fs.access("/etc/config/wireless")
+if not has_wireless then return end
+local has_antennas = fs.access("/etc/config/antennas")
+
+if not has_antennas then
+	luci.sys.exec("touch /etc/config/antennas")
+	local antennas = {}
+	antennas.builtin=true
+end
+
+-- Create antennas config
+uci:foreach("wireless", "wifi-device",
+function(sec)
+	if not uci:get("antennas", sec[".name"]) then
+		uci:section("antennas", "wifi-device", sec[".name"], {
+			builtin="true",
+			type="omni",
+			polarization="vertical"
+		})
+		uci:save("antennas")
+	end
+end)
+
+m = Map("antennas", translate("Antennas settings"), translate("Antennas settings"))
+uci:foreach("wireless", "wifi-device",
+function(sec)
+	s = m:section(NamedSection, sec[".name"], "wifi-device", "Wifi Device: "..sec[".name"])
+	s.remove = true
+	
+	svc = s:option(Flag, "builtin", "Built in")
+	
+	svc = s:option(Value, "manufacturer", translate("Manufacturer"))
+	svc:depends("builtin","")
+	svc.optional = true
+	svc:value("Huber & Suhner")
+	svc:value("Mars")
+	svc:value("Wimo")
+	svc:value("Rappl")
+	
+	
+	svc = s:option(Value, "model", translate("Model"))
+	svc:depends("builtin", "")
+	svc.optional = true
+	
+	svc = s:option(ListValue, "polarization", translate("Polarization"))
+	svc.optional = true
+	svc:value("vertical")
+	svc:value("horizontal")
+	svc:value("horizontal/vertical")
+	
+	-- Gain 0-100
+	svc = s:option(Value, "gain", "Gain", "dBi")
+	svc.optional = true
+	svc.datatype = "range(0,100)"
+	
+	svc = s:option(ListValue, "type", "Type")
+	svc.default = "omni"
+	svc:value("omni")
+	svc:value("directed")
+	
+	-- horizontalDirection 0-360
+	svc = s:option(Value, "horizontalDirection", translate("Horizontal Direction"), "0º - 360º")
+	svc:depends("type", "directed")
+	svc.optional = true
+	svc.datatype = "range(0,360)"
+	
+	-- horizontalBeamwidth 0-360
+	svc = s:option(Value, "horizontalBeamwidth", translate("Horizontal Beamwidth"), "0º - 360º")
+	svc:depends("type", "directed")
+	svc.optional = true
+	svc.datatype = "range(0,360)"
+	
+	-- verticalDirection -90,90
+	svc = s:option(Value, "verticalDirection", translate("Vertical Direction"), "-90º - 90º")
+	svc:depends("type", "directed")
+	svc.optional = true
+	svc.datatype = "range(-90,90)"
+	
+	-- verticalBeamwidth -90,90
+	svc = s:option(Value, "verticalBeamwidth", translate("Vertical Beamwidth"), "-90º - 90º")
+	svc:depends("type", "directed")
+	svc.optional = true
+	svc.datatype = "range(-90,90)"
+end)
+
+
+return m

--- a/applications/luci-app-owm/luasrc/owm.lua
+++ b/applications/luci-app-owm/luasrc/owm.lua
@@ -1,0 +1,514 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2013 Patrick Grimm <patrick@lunatiki.de>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+
+]]--
+
+local bus = require "ubus"
+local string = require "string"
+local sys = require "luci.sys"
+local uci = require "luci.model.uci".cursor_state()
+local util = require "luci.util"
+local json = require "luci.json"
+local netm = require "luci.model.network"
+local sysinfo = luci.util.ubus("system", "info") or { }
+local boardinfo = luci.util.ubus("system", "board") or { }
+local table = require "table"
+local nixio = require "nixio"
+local ip = require "luci.ip"
+
+local ipairs, pairs, tonumber, tostring = ipairs, pairs, tonumber, tostring
+local dofile, _G = dofile, _G
+
+--- LuCI OWM-Library
+-- @cstyle	instance
+module "luci.owm"
+
+-- backported from LuCI 0.11 and adapted form berlin-stats
+--- Returns the system type (in a compatible way to LuCI 0.11)
+-- @return	String indicating this as an deprecated value
+--        	(instead of the Chipset-type)
+-- @return	String containing hardware model information
+--        	(trimmed to router-model only)
+function sysinfo_for_kathleen020()
+	local cpuinfo = nixio.fs.readfile("/proc/cpuinfo")
+
+	local system = 'system is deprecated'
+
+	local model =
+		boardinfo['model'] or
+		cpuinfo:match("machine\t+: ([^\n]+)") or
+		cpuinfo:match("Hardware\t+: ([^\n]+)") or
+		nixio.uname().machine or
+		system
+
+        return system, model
+end
+
+-- inspired by luci.version
+--- Returns the system version info build from /etc/openwrt_release
+--- switch from luci.version which always includes
+--- the revision in the "distversion" field and gives empty "distname"
+-- @ return	the releasename
+--         	(DISTRIB_ID + DISTRIB_RELEASE)
+-- @ return	the releaserevision
+--         	(DISTRIB_REVISION)
+function get_version()
+	local distname = ""
+	local distrev = ""
+	local version = {}
+
+	dofile("/etc/openwrt_release")
+	if _G.DISTRIB_ID then
+		distname = _G.DISTRIB_ID .. " "
+	end
+	if _G.DISTRIB_RELEASE then
+		distname = distname .. _G.DISTRIB_RELEASE
+	end
+	if _G.DISTRIB_REVISION then
+		distrev = _G.DISTRIB_REVISION
+	end
+	version['distname'] = distname
+	version['distrevision'] = distrev
+	return version
+end
+
+function fetch_olsrd_config()
+	local data = {}
+	local IpVersion = uci:get_first("olsrd", "olsrd","IpVersion")
+	if IpVersion == "4" or IpVersion == "6and4" then
+		local jsonreq4 = util.exec("echo /config | nc 127.0.0.1 9090 2>/dev/null") or {}
+		local jsondata4 = json.decode(jsonreq4) or {}
+		if jsondata4['config'] then
+			data['ipv4Config'] = jsondata4['config']
+		end
+	end
+	if IpVersion == "6" or IpVersion == "6and4" then
+		local jsonreq6 = util.exec("echo /config | nc ::1 9090 2>/dev/null") or {}
+		local jsondata6 = json.decode(jsonreq6) or {}
+		if jsondata6['config'] then
+			data['ipv6Config'] = jsondata6['config']
+		end
+	end
+	return data
+end
+
+function fetch_olsrd_links()
+	local data = {}
+	local IpVersion = uci:get_first("olsrd", "olsrd","IpVersion")
+	if IpVersion == "4" or IpVersion == "6and4" then
+		local jsonreq4 = util.exec("echo /links | nc 127.0.0.1 9090 2>/dev/null") or {}
+		local jsondata4 = json.decode(jsonreq4) or {}
+		local links = {}
+		if jsondata4['links'] then
+			links = jsondata4['links']
+		end
+		for i,v in ipairs(links) do
+			links[i]['sourceAddr'] = v['localIP'] --owm sourceAddr
+			links[i]['destAddr'] = v['remoteIP'] --owm destAddr
+			local hostname = nixio.getnameinfo(v['remoteIP'], "inet")
+			if hostname then
+				links[i]['destNodeId'] = string.gsub(hostname, "mid..", "") --owm destNodeId
+			end
+		end
+		data = links
+	end
+	if IpVersion == "6" or IpVersion == "6and4" then
+		local jsonreq6 = util.exec("echo /links | nc ::1 9090 2>/dev/null") or {}
+		local jsondata6 = json.decode(jsonreq6) or {}
+		--print("fetch_olsrd_links v6 "..(jsondata6['links'] and #jsondata6['links'] or "err"))
+		local links = {}
+		if jsondata6['links'] then
+			links = jsondata6['links']
+		end
+		for i,v in ipairs(links) do
+			links[i]['sourceAddr'] = v['localIP']
+			links[i]['destAddr'] = v['remoteIP']
+			local hostname = nixio.getnameinfo(v['remoteIP'], "inet6")
+			if hostname then
+				links[i]['destNodeId'] = string.gsub(hostname, "mid..", "") --owm destNodeId
+			end
+			data[#data+1] = links[i]
+		end
+	end
+	return data
+end
+
+function fetch_olsrd_neighbors(interfaces)
+	local data = {}
+	local IpVersion = uci:get_first("olsrd", "olsrd","IpVersion")
+	if IpVersion == "4" or IpVersion == "6and4" then
+		local jsonreq4 = util.exec("echo /links | nc 127.0.0.1 9090 2>/dev/null") or {}
+		local jsondata4 = json.decode(jsonreq4) or {}
+		--print("fetch_olsrd_neighbors v4 "..(jsondata4['links'] and #jsondata4['links'] or "err"))
+		local links = {}
+		if jsondata4['links'] then
+			links = jsondata4['links']
+		end
+		for _,v in ipairs(links) do
+			local hostname = nixio.getnameinfo(v['remoteIP'], "inet")
+			if hostname then
+				hostname = string.gsub(hostname, "mid..", "")
+				local index = #data+1
+				data[index] = {}
+				data[index]['id'] = hostname --owm
+				data[index]['quality'] = v['linkQuality'] --owm
+				data[index]['sourceAddr4'] = v['localIP'] --owm
+				data[index]['destAddr4'] = v['remoteIP'] --owm
+				if #interfaces ~= 0 then
+					for _,iface in ipairs(interfaces) do
+						if iface['ipaddr'] == v['localIP'] then
+							data[index]['interface'] = iface['name'] --owm
+						end
+					end
+				end
+				data[index]['olsr_ipv4'] = v
+			end
+		end
+	end
+	if IpVersion == "6" or IpVersion == "6and4" then
+		local jsonreq6 = util.exec("echo /links | nc ::1 9090 2>/dev/null") or {}
+		local jsondata6 = json.decode(jsonreq6) or {}
+		local links = {}
+		if jsondata6['links'] then
+			links = jsondata6['links']
+		end
+		for _, link in ipairs(links) do
+			local hostname = nixio.getnameinfo(link['remoteIP'], "inet6")
+			if hostname then
+				hostname = string.gsub(hostname, "mid..", "")
+				local index = 0
+				for i, v in ipairs(data) do
+					if v.id == hostname then
+						index = i
+					end
+				end
+				if index == 0 then
+					index = #data+1
+					data[index] = {}
+					data[index]['id'] = string.gsub(hostname, "mid..", "") --owm
+					data[index]['quality'] = link['linkQuality'] --owm
+					if #interfaces ~= 0 then
+						for _,iface in ipairs(interfaces) do
+							local name = iface['.name']
+							local net = netm:get_network(name)
+							local device = net and net:get_interface()
+							if device and device:ip6addrs() then
+								local local_ip = ip.IPv6(link.localIP)
+								for _, a in ipairs(device:ip6addrs()) do
+									if a:host() == local_ip:host() then
+										data[index]['interface'] = name
+									end
+								end
+							end
+						end
+					end
+				end
+				data[index]['sourceAddr6'] = link['localIP'] --owm
+				data[index]['destAddr6'] = link['remoteIP'] --owm
+				data[index]['olsr_ipv6'] = link
+			end
+		end
+	end
+	return data
+end
+
+function fetch_olsrd()
+	local data = {}
+	data['links'] = fetch_olsrd_links()
+	local olsrconfig = fetch_olsrd_config()
+	data['ipv4Config'] = olsrconfig['ipv4Config']
+	data['ipv6Config'] = olsrconfig['ipv6Config']
+
+	return data
+end
+
+function showmac(mac)
+	if not is_admin then
+		mac = mac:gsub("(%S%S:%S%S):%S%S:%S%S:(%S%S:%S%S)", "%1:XX:XX:%2")
+	end
+	return mac
+end
+
+function get_position()
+	local position = {}
+	uci:foreach("system", "system", function(s)
+		position['latitude'] = tonumber(s.latitude)
+		position['longitude'] = tonumber(s.longitude)
+	end)
+	if (position['latitude'] and  position['longitude']) then
+		return position
+	else
+		return nil
+	end
+end
+
+function get()
+	local root = {}
+	local ntm = netm.init()
+	local devices  = ntm:get_wifidevs()
+	local assoclist = {}
+	local position = get_position()
+	local version = get_version()
+	for _, dev in ipairs(devices) do
+		for _, net in ipairs(dev:get_wifinets()) do
+			assoclist[#assoclist+1] = {}
+			assoclist[#assoclist]['ifname'] = net:ifname()
+			assoclist[#assoclist]['network'] = net:shortname()
+			assoclist[#assoclist]['device'] = dev:name()
+			assoclist[#assoclist]['list'] = net:assoclist()
+		end
+	end
+	root.type = 'node' --owm
+	root.updateInterval = 3600 --owm one hour
+
+	root.system = {
+		uptime = {sys.uptime()},
+		loadavg = {sysinfo.load[1] / 65536.0},
+		sysinfo = {sysinfo_for_kathleen020()},
+	}
+
+	root.hostname = sys.hostname() --owm
+	root.hardware = boardinfo['system'] --owm
+
+	root.firmware = {
+		name=version.distname, --owm
+		revision=version.distrevision --owm
+	}
+
+	root.freifunk = {}
+	uci:foreach("freifunk", "public", function(s)
+		local pname = s[".name"]
+		s['.name'] = nil
+		s['.anonymous'] = nil
+		s['.type'] = nil
+		s['.index'] = nil
+		if s['mail'] then
+			s['mail'] = string.gsub(s['mail'], "@", "./-\\.T.")
+		end
+		root.freifunk[pname] = s
+	end)
+
+	root.latitude = position["latitude"] --owm
+	root.longitude = position["longitude"] --owm
+
+	devices = {}
+	uci:foreach("wireless", "wifi-device",function(s)
+		devices[#devices+1] = s
+		devices[#devices]['name'] = s['.name']
+		devices[#devices]['.name'] = nil
+		devices[#devices]['.anonymous'] = nil
+		devices[#devices]['.type'] = nil
+		devices[#devices]['.index'] = nil
+		if s.macaddr then
+			devices[#devices]['macaddr'] = showmac(s.macaddr)
+		end
+	end)
+	local antennas = {}
+	uci:foreach("antennas", "wifi-device",function(s)
+		antennas[#antennas+1] = s
+		antennas[#antennas]['name'] = s['.name']
+		antennas[#antennas]['.name'] = nil
+		antennas[#antennas]['.anonymous'] = nil
+		antennas[#antennas]['.type'] = nil
+		antennas[#antennas]['.index'] = nil
+	end)
+
+	local interfaces = {}
+	uci:foreach("wireless", "wifi-iface",function(s)
+		interfaces[#interfaces+1] = s
+		interfaces[#interfaces]['.name'] = nil
+		interfaces[#interfaces]['.anonymous'] = nil
+		interfaces[#interfaces]['.type'] = nil
+		interfaces[#interfaces]['.index'] = nil
+		interfaces[#interfaces]['key'] = nil
+		interfaces[#interfaces]['key1'] = nil
+		interfaces[#interfaces]['key2'] = nil
+		interfaces[#interfaces]['key3'] = nil
+		interfaces[#interfaces]['key4'] = nil
+		interfaces[#interfaces]['auth_secret'] = nil
+		interfaces[#interfaces]['acct_secret'] = nil
+		interfaces[#interfaces]['nasid'] = nil
+		interfaces[#interfaces]['identity'] = nil
+		interfaces[#interfaces]['password'] = nil
+		local iwinfo = sys.wifi.getiwinfo(s.ifname)
+		if iwinfo then
+			for _, f in ipairs({
+			"channel", "txpower", "bitrate", "signal", "noise",
+			"quality", "quality_max", "mode", "ssid", "bssid", "encryption", "ifname"
+			}) do
+				interfaces[#interfaces][f] = iwinfo[f]
+			end
+			if iwinfo['encryption'] then
+				if iwinfo['encryption']['enabled'] then
+					-- fingers off encrypted wifi interfaces, they are likely private
+					table.remove(interfaces)
+					return
+				end
+			end
+		end
+		local assoclist_if = {}
+		for _, v in ipairs(assoclist) do
+			if v.network == interfaces[#interfaces]['network'] and v.list then
+				for assocmac, assot in pairs(v.list) do
+					assoclist_if[#assoclist_if+1] = assot
+					assoclist_if[#assoclist_if].mac = showmac(assocmac)
+				end
+			end
+		end
+		interfaces[#interfaces]['assoclist'] = assoclist_if
+		for _, device in ipairs(devices) do
+			if s['device'] == device.name then
+				interfaces[#interfaces]['wirelessdevice'] = device
+			end
+		end
+		for _, antenna in ipairs(antennas) do
+			if s['device'] == antenna.name then
+				interfaces[#interfaces]['wirelessdevice']['antenna'] = antenna --owm
+			end
+		end
+	end)
+
+	root.interfaces = {} --owm
+	uci:foreach("network", "interface",function(vif)
+		if 'lo' == vif.ifname then
+			return
+		end
+		local name = vif['.name']
+		if ('wan' == name) or ('wan6' == name) then
+			-- fingers off wan as this will be the private internet uplink
+			return
+		end
+		local net = netm:get_network(name)
+		local device = net and net:get_interface()
+		root.interfaces[#root.interfaces+1] =  vif
+		root.interfaces[#root.interfaces].name = name --owm
+		root.interfaces[#root.interfaces].ifname = vif.ifname --owm
+		root.interfaces[#root.interfaces].ipv4Addresses = {vif.ipaddr} --owm
+		local ipv6Addresses = {}
+		if device and device:ip6addrs() then
+			for _, a in ipairs(device:ip6addrs()) do
+				table.insert(ipv6Addresses, a:string())
+			end
+		end
+		root.interfaces[#root.interfaces].ipv6Addresses = ipv6Addresses --owm
+		root.interfaces[#root.interfaces].physicalType = 'ethernet' --owm
+		root.interfaces[#root.interfaces]['.name'] = nil
+		root.interfaces[#root.interfaces]['.anonymous'] = nil
+		root.interfaces[#root.interfaces]['.type'] = nil
+		root.interfaces[#root.interfaces]['.index'] = nil
+		root.interfaces[#root.interfaces]['username'] = nil
+		root.interfaces[#root.interfaces]['password'] = nil
+		root.interfaces[#root.interfaces]['password'] = nil
+		root.interfaces[#root.interfaces]['clientid'] = nil
+		root.interfaces[#root.interfaces]['reqopts'] = nil
+		root.interfaces[#root.interfaces]['pincode'] = nil
+		root.interfaces[#root.interfaces]['tunnelid'] = nil
+		root.interfaces[#root.interfaces]['tunnel_id'] = nil
+		root.interfaces[#root.interfaces]['peer_tunnel_id'] = nil
+		root.interfaces[#root.interfaces]['session_id'] = nil
+		root.interfaces[#root.interfaces]['peer_session_id'] = nil
+		if vif.macaddr then
+			root.interfaces[#root.interfaces]['macaddr'] = showmac(vif.macaddr)
+		end
+
+		local wireless_add = {}
+		for _, interface in ipairs(interfaces) do
+			if interface['network'] == name then
+				root.interfaces[#root.interfaces].physicalType = 'wifi' --owm
+				root.interfaces[#root.interfaces].mode = interface.mode
+				root.interfaces[#root.interfaces].encryption = interface.encryption
+				root.interfaces[#root.interfaces].access = 'free'
+				root.interfaces[#root.interfaces].accessNote = "everyone is welcome!"
+				root.interfaces[#root.interfaces].channel = interface.wirelessdevice.channel
+				root.interfaces[#root.interfaces].txpower = interface.wirelessdevice.txpower
+				root.interfaces[#root.interfaces].bssid = interface.bssid
+				root.interfaces[#root.interfaces].ssid = interface.ssid
+				root.interfaces[#root.interfaces].antenna = interface.wirelessdevice.antenna
+				wireless_add[#wireless_add+1] = interface --owm
+			end
+		end
+		root.interfaces[#root.interfaces].wifi = wireless_add
+	end)
+
+	local neighbors = fetch_olsrd_neighbors(root.interfaces)
+	local arptable = ip.neighbors() or {}
+	if #root.interfaces ~= 0 then
+		for idx,iface in ipairs(root.interfaces) do
+			local neigh_mac = {}
+			for _, arpt in ipairs(arptable) do
+				local mac = showmac(tostring(arpt['mac']):lower())
+				local ip_addr = tostring(arpt['dest'])
+				if iface['ifname'] == tostring(arpt['dev']) then
+					if not neigh_mac[mac] then
+						neigh_mac[mac] = {}
+						neigh_mac[mac]['ip4'] = {}
+					elseif not neigh_mac[mac]['ip4'] then
+						neigh_mac[mac]['ip4'] = {}
+					end
+					neigh_mac[mac]['ip4'][#neigh_mac[mac]['ip4']+1] = ip_addr
+					for i, neigh in ipairs(neighbors) do
+						if neigh['destAddr4'] == ip_addr then
+							neighbors[i]['mac'] = mac
+							neighbors[i]['ifname'] = iface['ifname']
+						end
+					end
+				end
+			end
+			for _, v in ipairs(assoclist) do
+				if v.ifname == iface['ifname'] and v.list then
+					for assocmac, assot in pairs(v.list) do
+						local mac = showmac(assocmac:lower())
+						if not neigh_mac[mac] then
+							neigh_mac[mac] = {}
+						end
+						if not neigh_mac[mac]['ip4'] then
+							neigh_mac[mac]['ip4'] = {}
+						end
+						if not neigh_mac[mac]['ip6'] then
+							neigh_mac[mac]['ip6'] = {}
+						end
+						neigh_mac[mac]['wifi'] = assot
+						for i, neigh in ipairs(neighbors) do
+							for _, ip_addr in ipairs(neigh_mac[mac]['ip4']) do
+								if neigh['destAddr4'] == ip_addr then
+									neighbors[i]['mac'] = mac
+									neighbors[i]['ifname'] = iface['ifname']
+									neighbors[i]['wifi'] = assot
+									neighbors[i]['signal'] = assot.signal
+									neighbors[i]['noise'] = assot.noise
+								end
+							end
+							for _, ip_addr in ipairs(neigh_mac[mac]['ip6']) do
+								if neigh['destAddr6'] == ip_addr then
+									neighbors[i]['mac'] = mac
+									neighbors[i]['ifname'] = iface['ifname']
+									neighbors[i]['wifi'] = assot
+									neighbors[i]['signal'] = assot.signal
+									neighbors[i]['noise'] = assot.noise
+								end
+							end
+						end
+					end
+				end
+			end
+			root.interfaces[idx].neighbors = neigh_mac
+		end
+	end
+
+	root.links = neighbors
+	root.olsr = fetch_olsrd()
+	root.script = 'luci-app-owm'
+	root.api_rev = '1.0'
+
+	return root
+end

--- a/applications/luci-app-owm/luasrc/view/owm.htm
+++ b/applications/luci-app-owm/luasrc/view/owm.htm
@@ -1,0 +1,38 @@
+<%
+local uci = require "luci.model.uci".cursor()
+local community = "profile_"..uci:get("freifunk", "community", "name")
+local mapserver = uci:get("freifunk", "community", "mapserver") or "http://openwifimap.net/"
+if type(mapserver)=="table" then
+	mapserver = mapserver[#mapserver]
+end
+local latitude = tonumber(uci:get_first("system", "system", "latitude"))
+local longitude = tonumber(uci:get_first("system", "system", "longitude"))
+local communityLatitude = tonumber(uci:get(community, "profile", "latitude"))
+local communityLongitude = tonumber(uci:get(community, "profile", "longitude"))
+local latitude1 = communityLatitude - 0.01
+local latitude2 = communityLatitude + 0.01
+local longitude1 = communityLongitude - 0.01
+local longitude2 = communityLongitude + 0.01
+if latitude then
+  latitude1 = latitude - 0.01
+  latitude2 = latitude + 0.01
+end
+if longitude then
+  longitude1 = longitude - 0.01
+  longitude2 = longitude + 0.01
+end
+%>
+
+<%+header%>
+
+<h3>
+	<a href="<%=mapserver%>/index.html#map?bbox=<%=latitude1%>,<%=longitude1%>,<%=latitude2%>,<%=longitude2%>">OpenWifiMap on <%=mapserver%></a>
+</h3>
+
+<iframe src="<%=mapserver%>/map.html#bbox=<%=latitude1%>,<%=longitude1%>,<%=latitude2%>,<%=longitude2%>" name="owm-iframe" width="100%" height="640px" frameborder="0" scrolling="no">
+</iframe>
+<br>
+<a href="/cgi-bin/luci/owm.json"> JSON daten owm.json</a>
+
+<%+footer%>
+


### PR DESCRIPTION
In the Freifunk-Berlin repo is a package that contains
* a command-line tool to publish node-data on the OWM
* a OWM-map app for LuCI
* an optional package to publish data of the antenna setup

As all relevant parts of the OWM-infrastructure are homed below the Freifunk organization, we should do the for the LuCI-app too. So other communities can easily use the code.