### PR TITLE
treewide: use $(AUTORELEASE) for all manually managed intree packages

### DIFF
--- a/applications/luci-app-owm/Makefile
+++ b/applications/luci-app-owm/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.5.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/community-profiles/Makefile
+++ b/contrib/package/community-profiles/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=community-profiles
-PKG_RELEASE:=4
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-common/Makefile
+++ b/contrib/package/freifunk-common/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-common
-PKG_RELEASE:=10
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-firewall/Makefile
+++ b/contrib/package/freifunk-firewall/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-firewall
-PKG_RELEASE:=3
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-gwcheck/Makefile
+++ b/contrib/package/freifunk-gwcheck/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-gwcheck
-PKG_RELEASE:=4
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-mapupdate/Makefile
+++ b/contrib/package/freifunk-mapupdate/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-mapupdate
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-policyrouting/Makefile
+++ b/contrib/package/freifunk-policyrouting/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-policyrouting
-PKG_RELEASE:=7
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-watchdog/Makefile
+++ b/contrib/package/freifunk-watchdog/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-watchdog
-PKG_RELEASE:=8
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 PKG_BUILD_DEPENDS := uci

--- a/contrib/package/meshwizard/Makefile
+++ b/contrib/package/meshwizard/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meshwizard
-PKG_RELEASE:=0.3.3
+PKG_RELEASE:=0.3.3-$(AUTORELEASE)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 


### PR DESCRIPTION
OpenWrt added the AUTORELEASE macro with 21.02 release (https://github.com/openwrt/openwrt/commit/9ae3c6f94c616cfbf854d3ec749c7fafc9893942) which counts the commits since last manual "bump" or "update".
In current workflows changing the PKG_RELEASE is often forgotten, which causes the same package-version after the code has changed. This causes some confusion to `opkg` and manual installation of the package.

special cases:
OWM: current version had a version number, but this had no real meaning
meshwizard: as the state of the package is unknown the AUTORELEASE number is
            just appended to the current versionnumber

