### PR TITLE
owm: add "hardwareinfo" node for modelname and system-platform

### DIFF
--- a/applications/luci-app-owm/Makefile
+++ b/applications/luci-app-owm/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.5.1
+PKG_RELEASE:=0.5.2
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/applications/luci-app-owm/luasrc/owm.lua
+++ b/applications/luci-app-owm/luasrc/owm.lua
@@ -33,27 +33,6 @@ local dofile, _G = dofile, _G
 -- @cstyle	instance
 module "luci.owm"
 
--- backported from LuCI 0.11 and adapted form berlin-stats
---- Returns the system type (in a compatible way to LuCI 0.11)
--- @return	String indicating this as an deprecated value
---        	(instead of the Chipset-type)
--- @return	String containing hardware model information
---        	(trimmed to router-model only)
-function sysinfo_for_kathleen020()
-	local cpuinfo = nixio.fs.readfile("/proc/cpuinfo")
-
-	local system = 'system is deprecated'
-
-	local model =
-		boardinfo['model'] or
-		cpuinfo:match("machine\t+: ([^\n]+)") or
-		cpuinfo:match("Hardware\t+: ([^\n]+)") or
-		nixio.uname().machine or
-		system
-
-        return system, model
-end
-
 -- inspired by luci.version
 --- Returns the system version info build from /etc/openwrt_release
 --- switch from luci.version which always includes
@@ -274,11 +253,14 @@ function get()
 	root.system = {
 		uptime = {sys.uptime()},
 		loadavg = {sysinfo.load[1] / 65536.0},
-		sysinfo = {sysinfo_for_kathleen020()},
 	}
 
 	root.hostname = sys.hostname() --owm
-	root.hardware = boardinfo['system'] --owm
+	root.hardwareinfo = {
+		system = boardinfo['system'], --owm
+		model = boardinfo['model'],
+		openwrt_boardname = boardinfo['board_name']
+	}
 
 	root.firmware = {
 		name=version.distname, --owm


### PR DESCRIPTION
* cleans the mixed use of hardware data and runtime data in the "system" node
  as mentioned in https://github.com/freifunk-berlin/firmware/issues/382
  * uses the "system" node only for runtime data
  * adds a new "hardwareinfo" node with a "model" and "system" field
    model: usually the marketing name from the type-label
    system: general hardware platform / SoC / reference-design
* drops some legacy compatibility code added in https://github.com/freifunk-berlin/firmware-packages/commit/222efe80f1c578a3a8f09fa7244fcab9f5c52395
  to support a statistics-page that have already shut down
* as the OWM-backend has been renewed recently, dropping the legacy code now
  seems the best moment

new JSON node
~~~
hardwareinfo |
  openwrt_boardname | "tplink,tl-wr841n-v13"
  model | "TP-Link TL-WR841N v13"
  system | "MediaTek MT7628AN ver:1 eco:2"
system |
  uptime |
    0 | 4692
  loadavg |
    0 | 0.12353515625
~~~

old JSON node
~~~
system |
  sysinfo |
    0 | "system is deprecated"
    1 | "TP-Link EAP225-Outdoor v1"
  uptime |
    0 | 651450
  loadavg |
    0 | 0.0244140625
~~~
