### PR TITLE
mod-freifunk: add UCI-setting to configure an alternative landingURL

### DIFF
--- a/modules/luci-mod-freifunk/ReadMe.md
+++ b/modules/luci-mod-freifunk/ReadMe.md
@@ -1,0 +1,21 @@
+# package "luci-mod-freifunk"
+
+This package provides a new function view to present some Freifunk relavant information. This View includes
+a "welcome page", "node info", "olsr info" (olsr-network summary, olsr-map) and a "testdownload" to check
+the bandwidth.  
+This view will become the initial page when accessing the node and the regular view ("luci-mod-admin-full",
+"luci-mod-admin-mini", "luci-mod-dashboard") need to be selected explicitly.
+
+## Customization
+
+This package can be customized via uci-config "freifunk"
+
+### section "luci"
+* option "redirect_landingpage": Will forward the user to another LuCI-page. This can be used to present an
+initial "setup Wizard".  
+Example `uci set freifunk.luci.redirect_landingpage="admin/status/overview`
+* option "redirect_landingurl": Will forward the use to any other URL This can be used to present an "setup
+Wizard" outside of LuCI or any other webpage. The redirect_landingpage option has higher priority when both
+are defined.  
+Example `uci set freifunk.luci.redirect_landingpage="/cgi-bin/fancy-wizard`
+

--- a/modules/luci-mod-freifunk/luasrc/view/freifunk/index.htm
+++ b/modules/luci-mod-freifunk/luasrc/view/freifunk/index.htm
@@ -10,10 +10,14 @@ local http = require "luci.http"
 
 local webAppRoot = http.getenv("PATH_INFO") == nil
 local redirectPage = uci:get("freifunk", "luci", "redirect_landingpage") or ""
+local redirectUrl = uci:get("freifunk", "luci", "redirect_landingurl") or ""
 
 if (webAppRoot and redirectPage ~= "") then
-        local url = luci.dispatcher.build_url(redirectPage)
-        http.redirect(url)
+	local url = luci.dispatcher.build_url(redirectPage)
+	http.redirect(url)
+end
+if (webAppRoot and redirectUrl ~= "") then
+	http.redirect(redirectUrl)
 end
 %>
 


### PR DESCRIPTION
This extends 21e69cd27d736f13295e2af79108617ccc694b45 by a way to define a regular URL as landingpage. In contrast to the 'redirect_landingpage' option this new option 'redirect_landingurl' allows to redirect to any webpage or any URL (relative or absolute) on the host.
The option 'redirect_landingpage' has higher priority than 'redirect_landingurl'. Both are defined in UCI-section "freifunk.luci".
