### PR TITLE
olsr_watchdog: handle empty "stamp" files

### DIFF
--- a/contrib/package/freifunk-common/files-olsrv1/usr/sbin/ff_olsr_watchdog
+++ b/contrib/package/freifunk-common/files-olsrv1/usr/sbin/ff_olsr_watchdog
@@ -22,7 +22,7 @@ if fs.access("/var/run/olsrd.pid") or fs.access("/var/run/olsrd4.pid") then
 
 	if intv and fs.access(stamp) then
 		local systime = os.time()
-		local wdgtime = tonumber(io.lines(stamp)())
+		local wdgtime = tonumber(io.lines(stamp)() or nil)
 
 		if not wdgtime or ( systime - wdgtime ) > ( intv * 2 ) then
 			os.execute("logger -t 'OLSR watchdog' 'Process died - restarting!'")


### PR DESCRIPTION
I've seen a olsrd that have been killed as of OoM. It happened in a way, that the stamp-file of the watchdog-plugin did not store the epoch.
This missing epoch made the script fail with 

~~~
/usr/bin/lua: /usr/sbin/ff_olsr_watchdog:42: bad argument #1 to 'tonumber' (value expected)
stack traceback:
      [C]: in function 'tonumber'
      /usr/sbin/ff_olsr_watchdog:42: in main chunk
~~~

To satisfy tonumber() just return `nil` in such situations and consider it as died olsr.
