### PR TITLE
Policyrouting: add list for Interfaces to ignore 

### DIFF
--- a/contrib/package/freifunk-policyrouting/Makefile
+++ b/contrib/package/freifunk-policyrouting/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-policyrouting
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/contrib/package/freifunk-policyrouting/files/etc/config/freifunk-policyrouting
+++ b/contrib/package/freifunk-policyrouting/files/etc/config/freifunk-policyrouting
@@ -4,4 +4,7 @@ config 'settings' 'pr'
 	option 'strict' '1'
 	option 'fallback' '1'
 	option 'zones' ''
+	list 'ignore_interface' 'loopback'
+	list 'ignore_interface' 'wan'
+	list 'ignore_interface' 'wan6'
 

--- a/contrib/package/freifunk-policyrouting/files/etc/hotplug.d/iface/30-policyrouting
+++ b/contrib/package/freifunk-policyrouting/files/etc/hotplug.d/iface/30-policyrouting
@@ -3,6 +3,9 @@
 . /lib/functions.sh
 . /lib/functions/network.sh
 
+IGNORE_INTERFACES=$(uci get freifunk-policyrouting.pr.ignore_interface)
+list_contains IGNORE_INTERFACES $INTERFACE && exit
+
 proto="4"
 [ -f /proc/net/ipv6_route ] && proto="4 6"
 
@@ -19,7 +22,7 @@ if [ "$ACTION" = "ifup" ] && [ "$enable" = "1" ]; then
 
 	if [ "$net" != "" -a -n "$dev" ]; then
 		eval $(/bin/ipcalc.sh $net)
-		if [ "$PREFIX" != "0" -a "$NETWORK" != "127.0.0.0" ]; then
+		if [ "$PREFIX" != "0" ]; then
 			if [ ! "$(ip r s t localnets |grep "$NETWORK/$PREFIX dev")" ]; then
 				cmd="ip r a $NETWORK/$PREFIX dev $dev table localnets"
 				$cmd


### PR DESCRIPTION
We don't need to consider several interfaces for policyrouting, so add a UCI-list for them to stop processing the hotplug-script.
The current ignores 127.0.0.0 already, so ignore "lookback" interface and also add "wan" and "wan6".
