### PR TITLE
add modemenu link to admin backend

### DIFF
--- a/modules/luci-mod-freifunk/root/usr/share/luci/menu.d/luci-mod-freifunk-frontend.json
+++ b/modules/luci-mod-freifunk/root/usr/share/luci/menu.d/luci-mod-freifunk-frontend.json
@@ -1,64 +1,72 @@
 {
-	"freifunk": {
-		"title": "Freifunk",
-		"order": 5,
-		"action": {
-			"type": "firstchild",
-			"recurse": true
-		}
-	},
-	"freifunk/index": {
-		"title": "Overview",
-		"order": 10,
-		"action": {
-			"type": "view",
-			"path": "freifunk/frontend/index"
-		}
-	},
-	"freifunk/contact": {
-		"title": "Contact",
-		"order": 15,
-		"action": {
-			"type": "view",
-			"path": "freifunk/frontend/contact"
-		}
-	},
-	"freifunk/status.json": {
-		"action": {
-			"type": "call",
-			"module": "luci.controller.freifunk.freifunk",
-			"function": "jsonstatus"
-		}
-	},
-	"freifunk/status": {
-		"title": "Status",
-		"order": 20,
-		"action": {
-			"type": "firstchild"
-		}
-	},
-	"freifunk/status/status": {
-		"title": "Status",
-		"order": 25,
-		"action": {
-			"type": "view",
-			"path": "freifunk/frontend/public_status"
-		}
-	},
-	"freifunk/status/zeroes": {
-		"title": "Testdownload",
-		"action": {
-			"type": "call",
-			"module": "luci.controller.freifunk.freifunk",
-			"function": "zeroes"
-		}
-	},
-	"freifunk/map": {
-		"title": "Map",
-		"order": 50,
-		"action": {
-			"type": "view",
-			"path": "freifunk/frontend/map/frame"
-		}
-	}
+  "freifunk": {
+    "title": "Freifunk",
+    "order": 5,
+    "action": {
+      "type": "firstchild",
+      "recurse": true
+    }
+  },
+  "admin": {
+    "title": "Administration",
+    "order": 6, 
+    "action": {
+      "type": "view",  
+      "path": "freifunk/admin/index"
+    }
+  },
+  "freifunk/index": {
+    "title": "Overview",
+    "order": 10,
+    "action": {
+      "type": "view",
+      "path": "freifunk/frontend/index"
+    }
+  },
+  "freifunk/contact": {
+    "title": "Contact",
+    "order": 15,
+    "action": {
+      "type": "view",
+      "path": "freifunk/frontend/contact"
+    }
+  },
+  "freifunk/status.json": {
+    "action": {
+      "type": "call",
+      "module": "luci.controller.freifunk.freifunk",
+      "function": "jsonstatus"
+    }
+  },
+  "freifunk/status": {
+    "title": "Status",
+    "order": 20,
+    "action": {
+      "type": "firstchild"
+    }
+  },
+  "freifunk/status/status": {
+    "title": "Status",
+    "order": 25,
+    "action": {
+      "type": "view",
+      "path": "freifunk/frontend/public_status"
+    }
+  },
+  "freifunk/status/zeroes": {
+    "title": "Testdownload",
+    "action": {
+      "type": "call",
+      "module": "luci.controller.freifunk.freifunk",
+      "function": "zeroes"
+    }
+  },
+  "freifunk/map": {
+    "title": "Map",
+    "order": 50,
+    "action": {
+      "type": "view",
+      "path": "freifunk/frontend/map/frame"
+    }
+  }
 }


### PR DESCRIPTION
This brings a link to the admin backend to the frontend.

![image](https://user-images.githubusercontent.com/1162168/151665691-da5e938e-87e0-4c87-83ea-82901c53d92b.png)

@jow- is this the correct way doing that? Before doing that, the modemenu link was only displayed while being logged in.